### PR TITLE
Update utils.js

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,7 +67,7 @@ const formatTime = ({
     .padStart(2, '0');
   const formattedMinutes = (Math.floor(time / 60) % 60)
     .toFixed(0)
-    .padStart(2, 'a]');
+    .padStart(2, '0');
   const formattedSeconds = Math.floor(time % 60)
     .toFixed(0)
     .padStart(2, '0');


### PR DESCRIPTION
formattedMinutes had .padStart(2, 'a]). 
Updated the second value to zero so when showHours is used, there will be a zero.