### PR TITLE
Support for reanimated v3 as peer dependency

### DIFF
--- a/packages/reanimated/package.json
+++ b/packages/reanimated/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "react-native": ">=0.46.0",
     "react-native-video": ">=2.0.0",
-    "react-native-reanimated": "^2.12.0",
+    "react-native-reanimated": ">=2.12.0 <4",
     "react-native-media-console": "^2.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Current peer dependency only applies to reanimated v2.
I thought It would be beneficial if it also supports for v3.