### PR TITLE
Propagate resizeMode prop value change to VideoPlayer's _resizeMode state

### DIFF
--- a/packages/media-console/src/VideoPlayer.tsx
+++ b/packages/media-console/src/VideoPlayer.tsx
@@ -327,6 +327,10 @@ const AnimatedVideoPlayer = (
   }, [paused]);
 
   useEffect(() => {
+    setResizeMode(resizeMode);
+  }, [resizeMode]);
+
+  useEffect(() => {
     if (_paused) {
       typeof events.onPause === 'function' && events.onPause();
     } else {


### PR DESCRIPTION
Allow changing the `resizeMode` property after the `VideoPlayer` component was mounted