### PR TITLE
Add additional files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,7 @@ node_modules
 npm-debug.log
 .DS_Store
 examples
+.babelrc
+.turbo
+yarn-error.log
+yarn.lock


### PR DESCRIPTION
# Why

After testing new metadata addition to the React Native Directory I have spotted that the media-console published package size is quite large. After investigating, looks like 2/3 of the total size (1.3 MiB) comes from `yarn-error.log`, `yarn.lock` and few other files in the dist, see:
* https://www.npmjs.com/package/react-native-media-console?activeTab=code

# How

Edit `.npmignore` content to include generated/config files. It should be 100% safe to ignore them in the npm package, see:
* https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files