### PR TITLE
fix(types): use react-jsx transform to fix JSX component type error in TypeScript 5.x

### DIFF
--- a/packages/media-console/tsconfig.json
+++ b/packages/media-console/tsconfig.json
@@ -4,7 +4,8 @@
     "allowUnusedLabels": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
     "lib": [
       "esnext"
     ],

--- a/packages/reanimated/tsconfig.json
+++ b/packages/reanimated/tsconfig.json
@@ -4,7 +4,8 @@
     "allowUnusedLabels": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
     "lib": [
       "esnext"
     ],


### PR DESCRIPTION
## Problem

Fixes #132

Users on TypeScript 5.1+ with React 18's updated `@types/react` see this error when using the library:

```
'react-native-media-console' cannot be used as a JSX component.
Its type '(props: Omit<VideoPlayerProps, "animations">) => Element' is not a valid JSX element type.
Type 'Element' is not assignable to type 'ReactNode | Promise<ReactNode>'.
Property 'children' is missing in type 'ReactElement<any, any>' but required in type 'ReactPortal'.
```

## Root Cause

Both `packages/media-console/tsconfig.json` and `packages/reanimated/tsconfig.json` use `"jsx": "react"`. With this setting, TypeScript generates declarations referencing the global `JSX.Element`. In React 18 + TypeScript 5.1+, the global `JSX` namespace was updated so that `JSX.Element` (`= React.ReactElement`) is no longer directly assignable to `ReactNode` in all contexts, breaking consumer type-checking.

## Fix

Switch both tsconfig files to `"jsx": "react-jsx"` and add `"jsxImportSource": "react"`. This uses the new automatic JSX runtime, causing TypeScript to emit `React.JSX.Element` in the generated `.d.ts` declarations, which is fully compatible with React 18's type hierarchy.

**Before** (generated `.d.ts`):
```ts
export declare const VideoPlayer: (props: Omit<VideoPlayerProps, 'animations'>) => JSX.Element;
```

**After** (generated `.d.ts`):
```ts
export declare const VideoPlayer: (props: Omit<VideoPlayerProps, 'animations'>) => React.JSX.Element;
```

No runtime behaviour is changed — only TypeScript type inference is affected. The Babel `react-native` preset already supports the automatic JSX runtime, so compilation is unaffected.